### PR TITLE
Improved Docker commands native support coverage

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/docker/client/deployment/DockerClientProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/docker/client/deployment/DockerClientProcessor.java
@@ -1,6 +1,10 @@
 package io.quarkiverse.docker.client.deployment;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import jakarta.inject.Singleton;
@@ -79,7 +83,8 @@ class DockerClientProcessor {
     }
 
     /**
-     * Sets up Docker clients at runtime initialization. Creates synthetic beans for both the default client and named clients.
+     * Sets up Docker clients at runtime initialization. Creates synthetic beans for both the default client and named
+     * clients.
      *
      * @param recorder The Docker client recorder
      * @param clientNames The collected Docker client names
@@ -170,10 +175,12 @@ class DockerClientProcessor {
     }
 
     @BuildStep
-    IndexDependencyBuildItem dockerJavaApiIndex() {
-        return new IndexDependencyBuildItem(
-                "com.github.docker-java",
-                "docker-java-api");
+    void dockerJavaApiIndex(BuildProducer<IndexDependencyBuildItem> indexDependencyProducer) {
+        indexDependencyProducer.produce(Set.of(
+                new IndexDependencyBuildItem(
+                        "com.github.docker-java", "docker-java-api"),
+                new IndexDependencyBuildItem(
+                        "com.github.docker-java", "docker-java-core")));
     }
 
     @BuildStep
@@ -185,7 +192,7 @@ class DockerClientProcessor {
 
         index.getIndex().getKnownClasses().stream()
                 .map(ci -> ci.name().toString())
-                .filter(name -> name.startsWith("com.github.dockerjava.api"))
+                .filter(name -> name.startsWith("com.github.dockerjava.api") || name.startsWith("com.github.dockerjava.core"))
                 .forEach(classes::add);
 
         reflectiveClasses.produce(
@@ -195,11 +202,7 @@ class DockerClientProcessor {
                         .fields()
                         .build());
 
-        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(
-                "com.github.dockerjava.core.DockerConfigFile",
-                "com.github.dockerjava.core.command.AbstrDockerCmd",
-                "com.github.dockerjava.core.command.CreateContainerCmdImpl",
-                "com.github.dockerjava.core.command.CreateNetworkCmdImpl")
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder("com.github.dockerjava.core.DockerConfigFile")
                 .constructors()
                 .methods()
                 .fields()
@@ -207,12 +210,14 @@ class DockerClientProcessor {
     }
 
     @BuildStep
-    public void runtimeInitialized(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClassProducer,
-            BuildProducer<RuntimeInitializedPackageBuildItem> runtimeInitializedPackageProducer,
-            BuildProducer<ReflectiveClassBuildItem> reflectiveClassProducer) {
+    public void runtimeInitialized(
+            BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClassProducer,
+            BuildProducer<RuntimeInitializedPackageBuildItem> runtimeInitializedPackageProducer) {
         runtimeInitializedClassProducer
-                .produce(new RuntimeInitializedClassBuildItem("com.github.dockerjava.transport.NamedPipeSocket$Kernel32"));
+                .produce(new RuntimeInitializedClassBuildItem(
+                        "com.github.dockerjava.transport.NamedPipeSocket$Kernel32"));
         runtimeInitializedPackageProducer
-                .produce(new RuntimeInitializedPackageBuildItem("org.apache.hc.client5.http.impl.auth"));
+                .produce(new RuntimeInitializedPackageBuildItem(
+                        "org.apache.hc.client5.http.impl.auth"));
     }
 }

--- a/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/ContainerResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/ContainerResource.java
@@ -1,0 +1,475 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkiverse.docker.client.it.cmd;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.model.ChangeLog;
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.api.model.HealthCheck;
+import com.github.dockerjava.api.model.Statistics;
+
+/**
+ * Mirrors docker-java's container command integration tests:
+ * CreateContainerCmdIT, StartContainerCmdIT, StopContainerCmdIT,
+ * KillContainerCmdIT, RestartContainerCmdImplIT, PauseCmdIT, UnpauseCmdIT,
+ * RenameContainerCmdIT, WaitContainerCmdIT, RemoveContainerCmdImplIT,
+ * ListContainersCmdIT, InspectContainerCmdIT, ContainerDiffCmdIT,
+ * ResizeContainerCmdIT, UpdateContainerCmdIT, LogContainerCmdIT, StatsCmdIT,
+ * HealthCmdIT, AttachContainerCmdIT, CopyArchiveToContainerCmdIT,
+ * CopyArchiveFromContainerCmdIT and CopyFileFromContainerCmdIT. Each docker
+ * command is exposed through its own REST endpoint.
+ */
+@Path("/docker-container")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+public class ContainerResource {
+
+    @Inject
+    DockerClient dockerClient;
+
+    // CreateContainerCmdIT#createContainer
+    @POST
+    @Path("/create")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response create(@QueryParam("image") String image,
+            @QueryParam("cmd") String cmd,
+            @QueryParam("name") String name,
+            @QueryParam("tty") boolean tty,
+            @QueryParam("stdinOpen") boolean stdinOpen,
+            @QueryParam("user") String user,
+            @QueryParam("env") List<String> env,
+            @QueryParam("label") List<String> labels,
+            @QueryParam("healthcheck") boolean healthcheck) throws InterruptedException {
+        try {
+            CreateContainerCmd createCmd = dockerClient.createContainerCmd(image);
+            if (cmd != null && !cmd.isEmpty()) {
+                createCmd.withCmd(cmd.split(","));
+            }
+            if (name != null && !name.isEmpty()) {
+                createCmd.withName(name);
+            }
+            if (tty) {
+                createCmd.withTty(true);
+            }
+            if (stdinOpen) {
+                createCmd.withStdinOpen(true);
+            }
+            if (user != null && !user.isEmpty()) {
+                createCmd.withUser(user);
+            }
+            if (env != null && !env.isEmpty()) {
+                createCmd.withEnv(env);
+            }
+            if (labels != null && !labels.isEmpty()) {
+                Map<String, String> labelMap = new HashMap<>();
+                for (String label : labels) {
+                    int idx = label.indexOf('=');
+                    if (idx > 0) {
+                        labelMap.put(label.substring(0, idx), label.substring(idx + 1));
+                    }
+                }
+                createCmd.withLabels(labelMap);
+            }
+            if (healthcheck) {
+                createCmd.withCmd("nc", "-l", "-p", "8080")
+                        .withHealthcheck(new HealthCheck()
+                                .withTest(Arrays.asList("CMD", "sh", "-c", "netstat -ltn | grep 8080"))
+                                .withInterval(TimeUnit.SECONDS.toNanos(1))
+                                .withTimeout(TimeUnit.MINUTES.toNanos(1))
+                                .withStartPeriod(TimeUnit.SECONDS.toNanos(30))
+                                .withRetries(10));
+            }
+            String id = createCmd.exec().getId();
+            return Response.ok(id).build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // StartContainerCmdIT#startContainer
+    @POST
+    @Path("/{id}/start")
+    public Response start(@PathParam("id") String id) {
+        try {
+            dockerClient.startContainerCmd(id).exec();
+            return Response.noContent().build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // StopContainerCmdIT#testStopContainer
+    @POST
+    @Path("/{id}/stop")
+    public Response stop(@PathParam("id") String id, @QueryParam("timeout") Integer timeout) {
+        try {
+            dockerClient.stopContainerCmd(id).withTimeout(timeout == null ? 10 : timeout).exec();
+            return Response.noContent().build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // KillContainerCmdIT#killContainer
+    @POST
+    @Path("/{id}/kill")
+    public Response kill(@PathParam("id") String id) {
+        try {
+            dockerClient.killContainerCmd(id).exec();
+            return Response.noContent().build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // RestartContainerCmdImplIT#restartContainer
+    @POST
+    @Path("/{id}/restart")
+    public Response restart(@PathParam("id") String id, @QueryParam("timeout") Integer timeout) {
+        try {
+            dockerClient.restartContainerCmd(id).withtTimeout(timeout == null ? 10 : timeout).exec();
+            return Response.noContent().build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // PauseCmdIT#pauseRunningContainer
+    @POST
+    @Path("/{id}/pause")
+    public Response pause(@PathParam("id") String id) {
+        try {
+            dockerClient.pauseContainerCmd(id).exec();
+            return Response.noContent().build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // UnpauseCmdIT#unpausePausedContainer
+    @POST
+    @Path("/{id}/unpause")
+    public Response unpause(@PathParam("id") String id) {
+        try {
+            dockerClient.unpauseContainerCmd(id).exec();
+            return Response.noContent().build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // RenameContainerCmdIT#renameContainer
+    @POST
+    @Path("/{id}/rename")
+    public Response rename(@PathParam("id") String id, @QueryParam("name") String name) {
+        try {
+            dockerClient.renameContainerCmd(id).withName(name).exec();
+            return Response.noContent().build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // WaitContainerCmdIT#testWaitContainer
+    @POST
+    @Path("/{id}/wait")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response waitContainer(@PathParam("id") String id) {
+        try {
+            int exitCode = dockerClient.waitContainerCmd(id).start().awaitStatusCode();
+            return Response.ok(String.valueOf(exitCode)).build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // RemoveContainerCmdImplIT#removeContainer
+    @DELETE
+    @Path("/{id}")
+    public Response remove(@PathParam("id") String id, @QueryParam("force") boolean force) {
+        try {
+            dockerClient.removeContainerCmd(id).withForce(force).exec();
+            return Response.noContent().build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // ListContainersCmdIT#testListContainers
+    @GET
+    public Response list(@QueryParam("label") List<String> labels) {
+        var cmd = dockerClient.listContainersCmd().withShowAll(true);
+        if (labels != null && !labels.isEmpty()) {
+            cmd.withLabelFilter(labels);
+        }
+        List<Container> containers = cmd.exec();
+        return Response.ok(containers).build();
+    }
+
+    // InspectContainerCmdIT#inspectContainer
+    @GET
+    @Path("/{id}/inspect")
+    public Response inspect(@PathParam("id") String id, @QueryParam("size") boolean size) {
+        try {
+            InspectContainerResponse response = dockerClient.inspectContainerCmd(id).withSize(size).exec();
+            return Response.ok(response).build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // ContainerDiffCmdIT#testContainerDiff
+    @GET
+    @Path("/{id}/diff")
+    public Response diff(@PathParam("id") String id) {
+        try {
+            List<ChangeLog> diff = dockerClient.containerDiffCmd(id).exec();
+            return Response.ok(diff).build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // ResizeContainerCmdIT#resizeContainerTtyTest
+    @POST
+    @Path("/{id}/resize")
+    public Response resize(@PathParam("id") String id,
+            @QueryParam("height") int height,
+            @QueryParam("width") int width) {
+        try {
+            dockerClient.resizeContainerCmd(id).withSize(height, width).exec();
+            return Response.noContent().build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // UpdateContainerCmdIT#updateContainer
+    @POST
+    @Path("/{id}/update")
+    public Response update(@PathParam("id") String id) {
+        try {
+            dockerClient.updateContainerCmd(id)
+                    .withCpuShares(512)
+                    .withCpuPeriod(100000L)
+                    .withCpuQuota(50000L)
+                    .withCpusetMems("0")
+                    .exec();
+            return Response.noContent().build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // LogContainerCmdIT#asyncMultipleLogContainer : collect container logs as text
+    @GET
+    @Path("/{id}/logs")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response logs(@PathParam("id") String id) throws InterruptedException {
+        final StringBuilder log = new StringBuilder();
+        dockerClient.logContainerCmd(id)
+                .withStdOut(true)
+                .withStdErr(true)
+                .withTailAll()
+                .exec(new ResultCallback.Adapter<Frame>() {
+                    @Override
+                    public void onNext(Frame frame) {
+                        log.append(new String(frame.getPayload(), StandardCharsets.UTF_8));
+                    }
+                })
+                .awaitCompletion(10, TimeUnit.SECONDS);
+        return Response.ok(log.toString()).build();
+    }
+
+    // StatsCmdIT#testStatsNoStreaming : return a single stats sample
+    @GET
+    @Path("/{id}/stats")
+    public Response stats(@PathParam("id") String id) throws InterruptedException, IOException {
+        final List<Statistics> collected = new ArrayList<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        try (ResultCallback.Adapter<Statistics> callback = dockerClient.statsCmd(id)
+                .withNoStream(true)
+                .exec(new ResultCallback.Adapter<Statistics>() {
+                    @Override
+                    public void onNext(Statistics stats) {
+                        if (stats != null) {
+                            collected.add(stats);
+                        }
+                        latch.countDown();
+                    }
+                })) {
+            latch.await(10, TimeUnit.SECONDS);
+        }
+        if (collected.isEmpty()) {
+            return Response.noContent().build();
+        }
+        return Response.ok(collected.get(0)).build();
+    }
+
+    // HealthCmdIT#healthiness : poll until the container becomes healthy
+    @GET
+    @Path("/{id}/health")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response health(@PathParam("id") String id) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(60);
+        String status = null;
+        while (System.currentTimeMillis() < deadline) {
+            InspectContainerResponse inspect = dockerClient.inspectContainerCmd(id).exec();
+            if (inspect.getState().getHealth() != null) {
+                status = inspect.getState().getHealth().getStatus();
+                if ("healthy".equals(status)) {
+                    break;
+                }
+            }
+            Thread.sleep(1000);
+        }
+        return Response.ok(status).build();
+    }
+
+    // CopyArchiveToContainerCmdIT#copyStreamToContainer : write a file then copy it in
+    @POST
+    @Path("/{id}/copy-to")
+    public Response copyTo(@PathParam("id") String id,
+            @QueryParam("remotePath") String remotePath,
+            @QueryParam("fileName") String fileName,
+            @QueryParam("content") String content) throws Exception {
+        File dir = Files.createTempDirectory("docker-java-copy").toFile();
+        File file = new File(dir, fileName);
+        Files.write(file.toPath(), (content == null ? "" : content).getBytes(StandardCharsets.UTF_8));
+        try {
+            dockerClient.copyArchiveToContainerCmd(id)
+                    .withRemotePath(remotePath == null ? "/" : remotePath)
+                    .withHostResource(file.getAbsolutePath())
+                    .exec();
+            return Response.noContent().build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        } finally {
+            file.delete();
+            dir.delete();
+        }
+    }
+
+    // CopyArchiveFromContainerCmdIT#copyFromContainer : export a path as a tar stream
+    @GET
+    @Path("/{id}/copy-from")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    public Response copyFrom(@PathParam("id") String id, @QueryParam("resource") String resource) {
+        try {
+            final InputStream in = dockerClient.copyArchiveFromContainerCmd(id, resource).exec();
+            StreamingOutput out = output -> {
+                try (InputStream stream = in) {
+                    stream.transferTo(output);
+                }
+            };
+            return Response.ok(out).build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // CopyFileFromContainerCmdIT#copyFromNonExistingContainer (deprecated cmd)
+    @GET
+    @Path("/{id}/copy-file-from")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    public Response copyFileFrom(@PathParam("id") String id, @QueryParam("resource") String resource) {
+        try {
+            final InputStream in = dockerClient.copyFileFromContainerCmd(id, resource).exec();
+            StreamingOutput out = output -> {
+                try (InputStream stream = in) {
+                    stream.transferTo(output);
+                }
+            };
+            return Response.ok(out).build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // AttachContainerCmdIT#attachContainerWithoutTTY : attach to a container and
+    // collect its output. The whole flow runs server-side because attaching needs
+    // to be wired up before the container is started.
+    @POST
+    @Path("/attach-scenario")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response attachScenario(@QueryParam("snippet") String snippet) throws Exception {
+        String text = (snippet == null || snippet.isEmpty()) ? "hello world" : snippet;
+        CreateContainerResponse container = dockerClient.createContainerCmd("busybox:latest")
+                .withCmd("echo", text)
+                .withTty(false)
+                .withAttachStdout(true)
+                .withAttachStderr(true)
+                .exec();
+
+        final StringBuilder collected = new StringBuilder();
+        try {
+            ResultCallback.Adapter<Frame> callback = dockerClient.attachContainerCmd(container.getId())
+                    .withStdErr(true)
+                    .withStdOut(true)
+                    .withFollowStream(true)
+                    .withLogs(true)
+                    .exec(new ResultCallback.Adapter<Frame>() {
+                        @Override
+                        public void onNext(Frame frame) {
+                            collected.append(new String(frame.getPayload(), StandardCharsets.UTF_8));
+                        }
+                    });
+            callback.awaitStarted(5, TimeUnit.SECONDS);
+            dockerClient.startContainerCmd(container.getId()).exec();
+            callback.awaitCompletion(30, TimeUnit.SECONDS);
+            callback.close();
+            return Response.ok(collected.toString()).build();
+        } finally {
+            try {
+                dockerClient.removeContainerCmd(container.getId()).withForce(true).exec();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+}

--- a/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/ContainerResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/ContainerResource.java
@@ -1,19 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.quarkiverse.docker.client.it.cmd;
 
 import java.io.File;
@@ -54,17 +38,6 @@ import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.HealthCheck;
 import com.github.dockerjava.api.model.Statistics;
 
-/**
- * Mirrors docker-java's container command integration tests:
- * CreateContainerCmdIT, StartContainerCmdIT, StopContainerCmdIT,
- * KillContainerCmdIT, RestartContainerCmdImplIT, PauseCmdIT, UnpauseCmdIT,
- * RenameContainerCmdIT, WaitContainerCmdIT, RemoveContainerCmdImplIT,
- * ListContainersCmdIT, InspectContainerCmdIT, ContainerDiffCmdIT,
- * ResizeContainerCmdIT, UpdateContainerCmdIT, LogContainerCmdIT, StatsCmdIT,
- * HealthCmdIT, AttachContainerCmdIT, CopyArchiveToContainerCmdIT,
- * CopyArchiveFromContainerCmdIT and CopyFileFromContainerCmdIT. Each docker
- * command is exposed through its own REST endpoint.
- */
 @Path("/docker-container")
 @ApplicationScoped
 @Produces(MediaType.APPLICATION_JSON)
@@ -73,7 +46,6 @@ public class ContainerResource {
     @Inject
     DockerClient dockerClient;
 
-    // CreateContainerCmdIT#createContainer
     @POST
     @Path("/create")
     @Produces(MediaType.TEXT_PLAIN)
@@ -132,7 +104,6 @@ public class ContainerResource {
         }
     }
 
-    // StartContainerCmdIT#startContainer
     @POST
     @Path("/{id}/start")
     public Response start(@PathParam("id") String id) {
@@ -144,7 +115,6 @@ public class ContainerResource {
         }
     }
 
-    // StopContainerCmdIT#testStopContainer
     @POST
     @Path("/{id}/stop")
     public Response stop(@PathParam("id") String id, @QueryParam("timeout") Integer timeout) {
@@ -156,7 +126,6 @@ public class ContainerResource {
         }
     }
 
-    // KillContainerCmdIT#killContainer
     @POST
     @Path("/{id}/kill")
     public Response kill(@PathParam("id") String id) {
@@ -168,7 +137,6 @@ public class ContainerResource {
         }
     }
 
-    // RestartContainerCmdImplIT#restartContainer
     @POST
     @Path("/{id}/restart")
     public Response restart(@PathParam("id") String id, @QueryParam("timeout") Integer timeout) {
@@ -180,7 +148,6 @@ public class ContainerResource {
         }
     }
 
-    // PauseCmdIT#pauseRunningContainer
     @POST
     @Path("/{id}/pause")
     public Response pause(@PathParam("id") String id) {
@@ -192,7 +159,6 @@ public class ContainerResource {
         }
     }
 
-    // UnpauseCmdIT#unpausePausedContainer
     @POST
     @Path("/{id}/unpause")
     public Response unpause(@PathParam("id") String id) {
@@ -204,7 +170,6 @@ public class ContainerResource {
         }
     }
 
-    // RenameContainerCmdIT#renameContainer
     @POST
     @Path("/{id}/rename")
     public Response rename(@PathParam("id") String id, @QueryParam("name") String name) {
@@ -216,7 +181,6 @@ public class ContainerResource {
         }
     }
 
-    // WaitContainerCmdIT#testWaitContainer
     @POST
     @Path("/{id}/wait")
     @Produces(MediaType.TEXT_PLAIN)
@@ -229,7 +193,6 @@ public class ContainerResource {
         }
     }
 
-    // RemoveContainerCmdImplIT#removeContainer
     @DELETE
     @Path("/{id}")
     public Response remove(@PathParam("id") String id, @QueryParam("force") boolean force) {
@@ -241,7 +204,6 @@ public class ContainerResource {
         }
     }
 
-    // ListContainersCmdIT#testListContainers
     @GET
     public Response list(@QueryParam("label") List<String> labels) {
         var cmd = dockerClient.listContainersCmd().withShowAll(true);
@@ -252,7 +214,6 @@ public class ContainerResource {
         return Response.ok(containers).build();
     }
 
-    // InspectContainerCmdIT#inspectContainer
     @GET
     @Path("/{id}/inspect")
     public Response inspect(@PathParam("id") String id, @QueryParam("size") boolean size) {
@@ -264,7 +225,6 @@ public class ContainerResource {
         }
     }
 
-    // ContainerDiffCmdIT#testContainerDiff
     @GET
     @Path("/{id}/diff")
     public Response diff(@PathParam("id") String id) {
@@ -276,7 +236,6 @@ public class ContainerResource {
         }
     }
 
-    // ResizeContainerCmdIT#resizeContainerTtyTest
     @POST
     @Path("/{id}/resize")
     public Response resize(@PathParam("id") String id,
@@ -290,7 +249,6 @@ public class ContainerResource {
         }
     }
 
-    // UpdateContainerCmdIT#updateContainer
     @POST
     @Path("/{id}/update")
     public Response update(@PathParam("id") String id) {
@@ -307,7 +265,6 @@ public class ContainerResource {
         }
     }
 
-    // LogContainerCmdIT#asyncMultipleLogContainer : collect container logs as text
     @GET
     @Path("/{id}/logs")
     @Produces(MediaType.TEXT_PLAIN)
@@ -327,7 +284,6 @@ public class ContainerResource {
         return Response.ok(log.toString()).build();
     }
 
-    // StatsCmdIT#testStatsNoStreaming : return a single stats sample
     @GET
     @Path("/{id}/stats")
     public Response stats(@PathParam("id") String id) throws InterruptedException, IOException {
@@ -352,7 +308,6 @@ public class ContainerResource {
         return Response.ok(collected.get(0)).build();
     }
 
-    // HealthCmdIT#healthiness : poll until the container becomes healthy
     @GET
     @Path("/{id}/health")
     @Produces(MediaType.TEXT_PLAIN)
@@ -372,7 +327,6 @@ public class ContainerResource {
         return Response.ok(status).build();
     }
 
-    // CopyArchiveToContainerCmdIT#copyStreamToContainer : write a file then copy it in
     @POST
     @Path("/{id}/copy-to")
     public Response copyTo(@PathParam("id") String id,
@@ -396,7 +350,6 @@ public class ContainerResource {
         }
     }
 
-    // CopyArchiveFromContainerCmdIT#copyFromContainer : export a path as a tar stream
     @GET
     @Path("/{id}/copy-from")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
@@ -414,7 +367,6 @@ public class ContainerResource {
         }
     }
 
-    // CopyFileFromContainerCmdIT#copyFromNonExistingContainer (deprecated cmd)
     @GET
     @Path("/{id}/copy-file-from")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
@@ -432,9 +384,6 @@ public class ContainerResource {
         }
     }
 
-    // AttachContainerCmdIT#attachContainerWithoutTTY : attach to a container and
-    // collect its output. The whole flow runs server-side because attaching needs
-    // to be wired up before the container is started.
     @POST
     @Path("/attach-scenario")
     @Produces(MediaType.TEXT_PLAIN)

--- a/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/ExecResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/ExecResource.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkiverse.docker.client.it.cmd;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.ExecCreateCmdResponse;
+import com.github.dockerjava.api.command.InspectExecResponse;
+import com.github.dockerjava.api.model.Frame;
+
+/**
+ * Mirrors docker-java's ExecCreateCmdImplIT, ExecStartCmdIT, InspectExecCmdIT
+ * and ResizeExecCmdIT. Each docker command is exposed through its own REST
+ * endpoint.
+ */
+@Path("/docker-exec")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+public class ExecResource {
+
+    private static final int TTY_HEIGHT = 30;
+    private static final int TTY_WIDTH = 120;
+
+    @Inject
+    DockerClient dockerClient;
+
+    // ExecCreateCmdImplIT#execCreateTest
+    @POST
+    @Path("/{containerId}/create")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response execCreate(@PathParam("containerId") String containerId,
+            @QueryParam("cmd") String cmd,
+            @QueryParam("tty") boolean tty) {
+        ExecCreateCmdResponse response = dockerClient.execCreateCmd(containerId)
+                .withAttachStdout(true)
+                .withAttachStderr(true)
+                .withTty(tty)
+                .withCmd(cmd.split(","))
+                .exec();
+        return Response.ok(response.getId()).build();
+    }
+
+    // ExecStartCmdIT#execStart : run the exec to completion
+    @POST
+    @Path("/{execId}/start")
+    public Response execStart(@PathParam("execId") String execId) throws InterruptedException {
+        dockerClient.execStartCmd(execId)
+                .withDetach(false)
+                .exec(new ResultCallback.Adapter<>())
+                .awaitCompletion();
+        return Response.noContent().build();
+    }
+
+    // InspectExecCmdIT#inspectExec
+    @GET
+    @Path("/{execId}/inspect")
+    public Response inspectExec(@PathParam("execId") String execId) {
+        InspectExecResponse response = dockerClient.inspectExecCmd(execId).exec();
+        return Response.ok(response).build();
+    }
+
+    // ResizeExecCmdIT#resizeExecInstanceTtyTest : run the full resize scenario and
+    // report whether the exec completed once its tty was resized to the target size.
+    @POST
+    @Path("/{containerId}/resize-scenario")
+    public Response resizeScenario(@PathParam("containerId") String containerId) throws InterruptedException {
+        ExecCreateCmdResponse exec = dockerClient.execCreateCmd(containerId)
+                .withTty(true)
+                .withAttachStdout(true)
+                .withAttachStderr(true)
+                .withCmd("sh", "-c",
+                        String.format("until stty size | grep '%d %d'; do : ; done", TTY_HEIGHT, TTY_WIDTH))
+                .exec();
+
+        ResultCallback.Adapter<Frame> callback = dockerClient.execStartCmd(exec.getId())
+                .exec(new ResultCallback.Adapter<>());
+        callback.awaitStarted();
+
+        dockerClient.resizeExecCmd(exec.getId()).withSize(TTY_HEIGHT, TTY_WIDTH).exec();
+
+        boolean completed = callback.awaitCompletion(10, TimeUnit.SECONDS);
+
+        Map<String, Boolean> result = Collections.singletonMap("completed", completed);
+        return Response.ok(result).build();
+    }
+}

--- a/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/ExecResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/ExecResource.java
@@ -1,19 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.quarkiverse.docker.client.it.cmd;
 
 import java.util.Collections;
@@ -37,11 +21,6 @@ import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.command.InspectExecResponse;
 import com.github.dockerjava.api.model.Frame;
 
-/**
- * Mirrors docker-java's ExecCreateCmdImplIT, ExecStartCmdIT, InspectExecCmdIT
- * and ResizeExecCmdIT. Each docker command is exposed through its own REST
- * endpoint.
- */
 @Path("/docker-exec")
 @ApplicationScoped
 @Produces(MediaType.APPLICATION_JSON)
@@ -53,7 +32,6 @@ public class ExecResource {
     @Inject
     DockerClient dockerClient;
 
-    // ExecCreateCmdImplIT#execCreateTest
     @POST
     @Path("/{containerId}/create")
     @Produces(MediaType.TEXT_PLAIN)
@@ -69,7 +47,6 @@ public class ExecResource {
         return Response.ok(response.getId()).build();
     }
 
-    // ExecStartCmdIT#execStart : run the exec to completion
     @POST
     @Path("/{execId}/start")
     public Response execStart(@PathParam("execId") String execId) throws InterruptedException {
@@ -80,7 +57,6 @@ public class ExecResource {
         return Response.noContent().build();
     }
 
-    // InspectExecCmdIT#inspectExec
     @GET
     @Path("/{execId}/inspect")
     public Response inspectExec(@PathParam("execId") String execId) {
@@ -88,8 +64,6 @@ public class ExecResource {
         return Response.ok(response).build();
     }
 
-    // ResizeExecCmdIT#resizeExecInstanceTtyTest : run the full resize scenario and
-    // report whether the exec completed once its tty was resized to the target size.
     @POST
     @Path("/{containerId}/resize-scenario")
     public Response resizeScenario(@PathParam("containerId") String containerId) throws InterruptedException {

--- a/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/ImageResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/ImageResource.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkiverse.docker.client.it.cmd;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.InspectImageResponse;
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.model.Image;
+
+/**
+ * Mirrors docker-java's ListImagesCmdIT, PullImageCmdIT, RemoveImageCmdIT,
+ * TagImageCmdIT, CommitCmdIT, SaveImageCmdIT, SaveImagesCmdIT, LoadImageCmdIT
+ * and BuildImageCmdIT. Each docker command is exposed through its own REST
+ * endpoint.
+ */
+@Path("/docker-image")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+public class ImageResource {
+
+    @Inject
+    DockerClient dockerClient;
+
+    // ListImagesCmdIT#listImages
+    @GET
+    public Response listImages() {
+        List<Image> images = dockerClient.listImagesCmd().withShowAll(true).exec();
+        return Response.ok(images).build();
+    }
+
+    // PullImageCmdIT#testPullImage
+    @POST
+    @Path("/pull")
+    public Response pullImage(@QueryParam("image") String image) throws InterruptedException {
+        dockerClient.pullImageCmd(image).start().awaitCompletion();
+        return Response.noContent().build();
+    }
+
+    // Test-setup helper: pull only when the image is not already cached locally.
+    // Used by the tests to guarantee an image is present without paying a registry
+    // round-trip (and possible timeout) on every run.
+    @POST
+    @Path("/ensure")
+    public Response ensureImage(@QueryParam("image") String image) throws InterruptedException {
+        try {
+            dockerClient.inspectImageCmd(image).exec();
+        } catch (NotFoundException notFound) {
+            dockerClient.pullImageCmd(image).start().awaitCompletion();
+        }
+        return Response.noContent().build();
+    }
+
+    // helper used by CommitCmdIT / PullImageCmdIT / BuildImageCmdIT (inspectImageCmd).
+    @GET
+    @Path("/inspect")
+    public Response inspectImage(@QueryParam("name") String name) {
+        try {
+            InspectImageResponse response = dockerClient.inspectImageCmd(name).exec();
+            return Response.ok(response).build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // RemoveImageCmdIT#removeImage / removeNonExistingImage
+    @DELETE
+    public Response removeImage(@QueryParam("name") String name, @QueryParam("force") boolean force) {
+        try {
+            dockerClient.removeImageCmd(name).withForce(force).exec();
+            return Response.noContent().build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // TagImageCmdIT#tagImage / tagNonExistingImage
+    @POST
+    @Path("/tag")
+    public Response tagImage(@QueryParam("image") String image,
+            @QueryParam("repository") String repository,
+            @QueryParam("tag") String tag) {
+        try {
+            dockerClient.tagImageCmd(image, repository, tag).exec();
+            return Response.noContent().build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // CommitCmdIT#commit
+    @POST
+    @Path("/commit/{containerId}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response commit(@PathParam("containerId") String containerId) {
+        try {
+            String imageId = dockerClient.commitCmd(containerId).exec();
+            return Response.ok(imageId).build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // CommitCmdIT#commitWithLabels
+    @POST
+    @Path("/commit/{containerId}/labels")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response commitWithLabels(@PathParam("containerId") String containerId) {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("label1", "abc");
+        labels.put("label2", "123");
+        String imageId = dockerClient.commitCmd(containerId).withLabels(labels).exec();
+        return Response.ok(imageId).build();
+    }
+
+    // SaveImageCmdIT#saveImage
+    @GET
+    @Path("/save")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    public Response saveImage(@QueryParam("name") String name, @QueryParam("tag") String tag) {
+        final InputStream in = (tag == null || tag.isEmpty())
+                ? dockerClient.saveImageCmd(name).exec()
+                : dockerClient.saveImageCmd(name).withTag(tag).exec();
+        StreamingOutput out = output -> {
+            try (InputStream stream = in) {
+                stream.transferTo(output);
+            }
+        };
+        return Response.ok(out).build();
+    }
+
+    // SaveImagesCmdIT#saveNoImages / saveImagesWithNameAndTag
+    @GET
+    @Path("/save-images")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    public Response saveImages(@QueryParam("repository") String repository, @QueryParam("tag") String tag) {
+        final InputStream in = (repository == null || repository.isEmpty())
+                ? dockerClient.saveImagesCmd().exec()
+                : dockerClient.saveImagesCmd().withImage(repository, tag).exec();
+        StreamingOutput out = output -> {
+            try (InputStream stream = in) {
+                stream.transferTo(output);
+            }
+        };
+        return Response.ok(out).build();
+    }
+
+    // LoadImageCmdIT#loadImageFromTar : save an existing image to a tar and load it back.
+    @POST
+    @Path("/load")
+    public Response loadImage(@QueryParam("name") String name) throws Exception {
+        byte[] tar;
+        try (InputStream saved = dockerClient.saveImageCmd(name).exec();
+                ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+            saved.transferTo(buffer);
+            tar = buffer.toByteArray();
+        }
+        try (InputStream upload = new ByteArrayInputStream(tar)) {
+            dockerClient.loadImageCmd(upload).exec();
+        }
+        return Response.noContent().build();
+    }
+
+    // BuildImageCmdIT#labels : build a minimal image from a generated Dockerfile.
+    @POST
+    @Path("/build")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response buildImage(@QueryParam("from") String from) throws Exception {
+        String baseImage = (from == null || from.isEmpty()) ? "busybox:latest" : from;
+        File baseDir = Files.createTempDirectory("docker-java-build").toFile();
+        try {
+            File dockerfile = new File(baseDir, "Dockerfile");
+            Files.write(dockerfile.toPath(), ("FROM " + baseImage + "\n").getBytes(StandardCharsets.UTF_8));
+
+            String imageId = dockerClient.buildImageCmd(baseDir)
+                    .withNoCache(true)
+                    .withLabels(Collections.singletonMap("test", "abc"))
+                    .start()
+                    .awaitImageId();
+            return Response.ok(imageId).build();
+        } finally {
+            new File(baseDir, "Dockerfile").delete();
+            baseDir.delete();
+        }
+    }
+}

--- a/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/ImageResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/ImageResource.java
@@ -1,19 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.quarkiverse.docker.client.it.cmd;
 
 import java.io.ByteArrayInputStream;
@@ -45,12 +29,6 @@ import com.github.dockerjava.api.command.InspectImageResponse;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Image;
 
-/**
- * Mirrors docker-java's ListImagesCmdIT, PullImageCmdIT, RemoveImageCmdIT,
- * TagImageCmdIT, CommitCmdIT, SaveImageCmdIT, SaveImagesCmdIT, LoadImageCmdIT
- * and BuildImageCmdIT. Each docker command is exposed through its own REST
- * endpoint.
- */
 @Path("/docker-image")
 @ApplicationScoped
 @Produces(MediaType.APPLICATION_JSON)
@@ -59,14 +37,12 @@ public class ImageResource {
     @Inject
     DockerClient dockerClient;
 
-    // ListImagesCmdIT#listImages
     @GET
     public Response listImages() {
         List<Image> images = dockerClient.listImagesCmd().withShowAll(true).exec();
         return Response.ok(images).build();
     }
 
-    // PullImageCmdIT#testPullImage
     @POST
     @Path("/pull")
     public Response pullImage(@QueryParam("image") String image) throws InterruptedException {
@@ -74,9 +50,6 @@ public class ImageResource {
         return Response.noContent().build();
     }
 
-    // Test-setup helper: pull only when the image is not already cached locally.
-    // Used by the tests to guarantee an image is present without paying a registry
-    // round-trip (and possible timeout) on every run.
     @POST
     @Path("/ensure")
     public Response ensureImage(@QueryParam("image") String image) throws InterruptedException {
@@ -88,7 +61,6 @@ public class ImageResource {
         return Response.noContent().build();
     }
 
-    // helper used by CommitCmdIT / PullImageCmdIT / BuildImageCmdIT (inspectImageCmd).
     @GET
     @Path("/inspect")
     public Response inspectImage(@QueryParam("name") String name) {
@@ -100,7 +72,6 @@ public class ImageResource {
         }
     }
 
-    // RemoveImageCmdIT#removeImage / removeNonExistingImage
     @DELETE
     public Response removeImage(@QueryParam("name") String name, @QueryParam("force") boolean force) {
         try {
@@ -111,7 +82,6 @@ public class ImageResource {
         }
     }
 
-    // TagImageCmdIT#tagImage / tagNonExistingImage
     @POST
     @Path("/tag")
     public Response tagImage(@QueryParam("image") String image,
@@ -125,7 +95,6 @@ public class ImageResource {
         }
     }
 
-    // CommitCmdIT#commit
     @POST
     @Path("/commit/{containerId}")
     @Produces(MediaType.TEXT_PLAIN)
@@ -138,7 +107,6 @@ public class ImageResource {
         }
     }
 
-    // CommitCmdIT#commitWithLabels
     @POST
     @Path("/commit/{containerId}/labels")
     @Produces(MediaType.TEXT_PLAIN)
@@ -150,7 +118,6 @@ public class ImageResource {
         return Response.ok(imageId).build();
     }
 
-    // SaveImageCmdIT#saveImage
     @GET
     @Path("/save")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
@@ -166,7 +133,6 @@ public class ImageResource {
         return Response.ok(out).build();
     }
 
-    // SaveImagesCmdIT#saveNoImages / saveImagesWithNameAndTag
     @GET
     @Path("/save-images")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
@@ -182,7 +148,6 @@ public class ImageResource {
         return Response.ok(out).build();
     }
 
-    // LoadImageCmdIT#loadImageFromTar : save an existing image to a tar and load it back.
     @POST
     @Path("/load")
     public Response loadImage(@QueryParam("name") String name) throws Exception {
@@ -198,7 +163,6 @@ public class ImageResource {
         return Response.noContent().build();
     }
 
-    // BuildImageCmdIT#labels : build a minimal image from a generated Dockerfile.
     @POST
     @Path("/build")
     @Produces(MediaType.TEXT_PLAIN)

--- a/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/NetworkResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/NetworkResource.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkiverse.docker.client.it.cmd;
+
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.CreateNetworkResponse;
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.model.Network;
+
+/**
+ * Mirrors docker-java's CreateNetworkCmdIT, InspectNetworkCmdIT,
+ * ListNetworksCmdIT, RemoveNetworkCmdIT, ConnectToNetworkCmdIT and
+ * DisconnectFromNetworkCmdIT. Each docker command is exposed through its own
+ * REST endpoint.
+ */
+@Path("/docker-network")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+public class NetworkResource {
+
+    @Inject
+    DockerClient dockerClient;
+
+    // CreateNetworkCmdIT#createNetwork
+    @POST
+    @Path("/{name}")
+    public Response createNetwork(@PathParam("name") String name) {
+        CreateNetworkResponse response = dockerClient.createNetworkCmd().withName(name).exec();
+        return Response.ok(response).build();
+    }
+
+    // CreateNetworkCmdIT#createNetworkWithIpamConfig
+    @POST
+    @Path("/{name}/ipam")
+    public Response createNetworkWithIpam(@PathParam("name") String name, @QueryParam("subnet") String subnet) {
+        Network.Ipam ipam = new Network.Ipam().withConfig(new Network.Ipam.Config().withSubnet(subnet));
+        CreateNetworkResponse response = dockerClient.createNetworkCmd().withName(name).withIpam(ipam).exec();
+        return Response.ok(response).build();
+    }
+
+    // CreateNetworkCmdIT#createNetworkWithLabel
+    @POST
+    @Path("/{name}/label")
+    public Response createNetworkWithLabel(@PathParam("name") String name) {
+        CreateNetworkResponse response = dockerClient.createNetworkCmd()
+                .withName(name)
+                .withLabels(Collections.singletonMap("com.example.usage", "test"))
+                .exec();
+        return Response.ok(response).build();
+    }
+
+    // CreateNetworkCmdIT#createAttachableNetwork
+    @POST
+    @Path("/{name}/attachable")
+    public Response createAttachableNetwork(@PathParam("name") String name) {
+        CreateNetworkResponse response = dockerClient.createNetworkCmd()
+                .withName(name)
+                .withAttachable(true)
+                .exec();
+        return Response.ok(response).build();
+    }
+
+    // ListNetworksCmdIT#listNetworks
+    @GET
+    public Response listNetworks() {
+        List<Network> networks = dockerClient.listNetworksCmd().exec();
+        return Response.ok(networks).build();
+    }
+
+    // InspectNetworkCmdIT#inspectNetwork
+    @GET
+    @Path("/{networkId}")
+    public Response inspectNetwork(@PathParam("networkId") String networkId) {
+        try {
+            Network network = dockerClient.inspectNetworkCmd().withNetworkId(networkId).exec();
+            return Response.ok(network).build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // RemoveNetworkCmdIT#removeNetwork / removeNonExistingContainer
+    @DELETE
+    @Path("/{networkId}")
+    public Response removeNetwork(@PathParam("networkId") String networkId) {
+        try {
+            dockerClient.removeNetworkCmd(networkId).exec();
+            return Response.noContent().build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // ConnectToNetworkCmdIT#connectToNetwork
+    @POST
+    @Path("/{networkId}/connect/{containerId}")
+    public Response connectToNetwork(@PathParam("networkId") String networkId,
+            @PathParam("containerId") String containerId) {
+        dockerClient.connectToNetworkCmd().withNetworkId(networkId).withContainerId(containerId).exec();
+        return Response.noContent().build();
+    }
+
+    // DisconnectFromNetworkCmdIT#disconnectFromNetwork
+    @POST
+    @Path("/{networkId}/disconnect/{containerId}")
+    public Response disconnectFromNetwork(@PathParam("networkId") String networkId,
+            @PathParam("containerId") String containerId,
+            @QueryParam("force") boolean force) {
+        dockerClient.disconnectFromNetworkCmd()
+                .withNetworkId(networkId)
+                .withContainerId(containerId)
+                .withForce(force)
+                .exec();
+        return Response.noContent().build();
+    }
+}

--- a/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/NetworkResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/NetworkResource.java
@@ -1,19 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.quarkiverse.docker.client.it.cmd;
 
 import java.util.Collections;
@@ -36,12 +20,6 @@ import com.github.dockerjava.api.command.CreateNetworkResponse;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Network;
 
-/**
- * Mirrors docker-java's CreateNetworkCmdIT, InspectNetworkCmdIT,
- * ListNetworksCmdIT, RemoveNetworkCmdIT, ConnectToNetworkCmdIT and
- * DisconnectFromNetworkCmdIT. Each docker command is exposed through its own
- * REST endpoint.
- */
 @Path("/docker-network")
 @ApplicationScoped
 @Produces(MediaType.APPLICATION_JSON)
@@ -50,7 +28,6 @@ public class NetworkResource {
     @Inject
     DockerClient dockerClient;
 
-    // CreateNetworkCmdIT#createNetwork
     @POST
     @Path("/{name}")
     public Response createNetwork(@PathParam("name") String name) {
@@ -58,7 +35,6 @@ public class NetworkResource {
         return Response.ok(response).build();
     }
 
-    // CreateNetworkCmdIT#createNetworkWithIpamConfig
     @POST
     @Path("/{name}/ipam")
     public Response createNetworkWithIpam(@PathParam("name") String name, @QueryParam("subnet") String subnet) {
@@ -67,7 +43,6 @@ public class NetworkResource {
         return Response.ok(response).build();
     }
 
-    // CreateNetworkCmdIT#createNetworkWithLabel
     @POST
     @Path("/{name}/label")
     public Response createNetworkWithLabel(@PathParam("name") String name) {
@@ -78,7 +53,6 @@ public class NetworkResource {
         return Response.ok(response).build();
     }
 
-    // CreateNetworkCmdIT#createAttachableNetwork
     @POST
     @Path("/{name}/attachable")
     public Response createAttachableNetwork(@PathParam("name") String name) {
@@ -89,14 +63,12 @@ public class NetworkResource {
         return Response.ok(response).build();
     }
 
-    // ListNetworksCmdIT#listNetworks
     @GET
     public Response listNetworks() {
         List<Network> networks = dockerClient.listNetworksCmd().exec();
         return Response.ok(networks).build();
     }
 
-    // InspectNetworkCmdIT#inspectNetwork
     @GET
     @Path("/{networkId}")
     public Response inspectNetwork(@PathParam("networkId") String networkId) {
@@ -108,7 +80,6 @@ public class NetworkResource {
         }
     }
 
-    // RemoveNetworkCmdIT#removeNetwork / removeNonExistingContainer
     @DELETE
     @Path("/{networkId}")
     public Response removeNetwork(@PathParam("networkId") String networkId) {
@@ -120,7 +91,6 @@ public class NetworkResource {
         }
     }
 
-    // ConnectToNetworkCmdIT#connectToNetwork
     @POST
     @Path("/{networkId}/connect/{containerId}")
     public Response connectToNetwork(@PathParam("networkId") String networkId,
@@ -129,7 +99,6 @@ public class NetworkResource {
         return Response.noContent().build();
     }
 
-    // DisconnectFromNetworkCmdIT#disconnectFromNetwork
     @POST
     @Path("/{networkId}/disconnect/{containerId}")
     public Response disconnectFromNetwork(@PathParam("networkId") String networkId,

--- a/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/SystemResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/SystemResource.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkiverse.docker.client.it.cmd;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.model.Event;
+import com.github.dockerjava.api.model.Info;
+import com.github.dockerjava.api.model.Version;
+
+/**
+ * Mirrors docker-java's InfoCmdIT, VersionCmdIT, PingCmdIT and EventsCmdIT.
+ * Each docker command is exposed through its own REST endpoint.
+ */
+@Path("/docker-system")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+public class SystemResource {
+
+    private static final String EVENTS_IMAGE = "busybox:latest";
+
+    @Inject
+    DockerClient dockerClient;
+
+    // InfoCmdIT#infoTest
+    @GET
+    @Path("/info")
+    public Response info() {
+        Info info = dockerClient.infoCmd().exec();
+        return Response.ok(info).build();
+    }
+
+    // VersionCmdIT#version
+    @GET
+    @Path("/version")
+    public Response version() {
+        Version version = dockerClient.versionCmd().exec();
+        return Response.ok(version).build();
+    }
+
+    // PingCmdIT#ping
+    @GET
+    @Path("/ping")
+    public Response ping() {
+        dockerClient.pingCmd().exec();
+        return Response.noContent().build();
+    }
+
+    // EventsCmdIT#testEventStreamTimeBound : generate events inside a time window
+    // and collect them via a since/until bound events stream.
+    @GET
+    @Path("/events")
+    public Response events() throws Exception {
+        String startTime = epochSeconds();
+        generateEvents();
+        String endTime = epochSeconds();
+
+        List<Event> events = new ArrayList<>();
+        try (ResultCallback.Adapter<Event> callback = dockerClient.eventsCmd()
+                .withSince(startTime)
+                .withUntil(endTime)
+                .exec(new ResultCallback.Adapter<Event>() {
+                    @Override
+                    public void onNext(Event event) {
+                        events.add(event);
+                    }
+                })) {
+            callback.awaitCompletion(30, TimeUnit.SECONDS);
+        }
+        return Response.ok(events).build();
+    }
+
+    private static String epochSeconds() {
+        return String.valueOf(System.currentTimeMillis() / 1000);
+    }
+
+    private void generateEvents() throws InterruptedException {
+        // Only pull when the image is not already cached locally (avoids hitting
+        // the registry on every run).
+        try {
+            dockerClient.inspectImageCmd(EVENTS_IMAGE).exec();
+        } catch (NotFoundException notFound) {
+            dockerClient.pullImageCmd(EVENTS_IMAGE).start().awaitCompletion();
+        }
+        CreateContainerResponse container = dockerClient.createContainerCmd(EVENTS_IMAGE)
+                .withCmd("sleep", "9999")
+                .exec();
+        dockerClient.startContainerCmd(container.getId()).exec();
+        dockerClient.stopContainerCmd(container.getId()).withTimeout(1).exec();
+        dockerClient.removeContainerCmd(container.getId()).withForce(true).exec();
+    }
+}

--- a/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/SystemResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/SystemResource.java
@@ -1,19 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.quarkiverse.docker.client.it.cmd;
 
 import java.util.ArrayList;
@@ -36,10 +20,6 @@ import com.github.dockerjava.api.model.Event;
 import com.github.dockerjava.api.model.Info;
 import com.github.dockerjava.api.model.Version;
 
-/**
- * Mirrors docker-java's InfoCmdIT, VersionCmdIT, PingCmdIT and EventsCmdIT.
- * Each docker command is exposed through its own REST endpoint.
- */
 @Path("/docker-system")
 @ApplicationScoped
 @Produces(MediaType.APPLICATION_JSON)
@@ -50,7 +30,6 @@ public class SystemResource {
     @Inject
     DockerClient dockerClient;
 
-    // InfoCmdIT#infoTest
     @GET
     @Path("/info")
     public Response info() {
@@ -58,7 +37,6 @@ public class SystemResource {
         return Response.ok(info).build();
     }
 
-    // VersionCmdIT#version
     @GET
     @Path("/version")
     public Response version() {
@@ -66,7 +44,6 @@ public class SystemResource {
         return Response.ok(version).build();
     }
 
-    // PingCmdIT#ping
     @GET
     @Path("/ping")
     public Response ping() {
@@ -74,8 +51,6 @@ public class SystemResource {
         return Response.noContent().build();
     }
 
-    // EventsCmdIT#testEventStreamTimeBound : generate events inside a time window
-    // and collect them via a since/until bound events stream.
     @GET
     @Path("/events")
     public Response events() throws Exception {
@@ -103,8 +78,7 @@ public class SystemResource {
     }
 
     private void generateEvents() throws InterruptedException {
-        // Only pull when the image is not already cached locally (avoids hitting
-        // the registry on every run).
+
         try {
             dockerClient.inspectImageCmd(EVENTS_IMAGE).exec();
         } catch (NotFoundException notFound) {

--- a/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/VolumeResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/VolumeResource.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkiverse.docker.client.it.cmd;
+
+import java.util.Collections;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.CreateVolumeResponse;
+import com.github.dockerjava.api.command.InspectVolumeResponse;
+import com.github.dockerjava.api.command.ListVolumesResponse;
+import com.github.dockerjava.api.exception.NotFoundException;
+
+/**
+ * Mirrors docker-java's CreateVolumeCmdIT, InspectVolumeCmdIT, ListVolumesCmdIT
+ * and RemoveVolumeCmdIT. Each docker command is exposed through its own REST
+ * endpoint.
+ */
+@Path("/docker-volume")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+public class VolumeResource {
+
+    @Inject
+    DockerClient dockerClient;
+
+    // CreateVolumeCmdIT#createVolume
+    @POST
+    @Path("/{name}")
+    public Response createVolume(@PathParam("name") String name) {
+        CreateVolumeResponse response = dockerClient.createVolumeCmd()
+                .withName(name)
+                .withDriver("local")
+                .withLabels(Collections.singletonMap("is-timelord", "yes"))
+                .exec();
+        return Response.ok(response).build();
+    }
+
+    // InspectVolumeCmdIT#inspectVolume / inspectNonExistentVolume
+    @GET
+    @Path("/{name}")
+    public Response inspectVolume(@PathParam("name") String name) {
+        try {
+            InspectVolumeResponse response = dockerClient.inspectVolumeCmd(name).exec();
+            return Response.ok(response).build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    // ListVolumesCmdIT#listVolumes
+    @GET
+    public Response listVolumes() {
+        ListVolumesResponse response = dockerClient.listVolumesCmd().exec();
+        return Response.ok(response).build();
+    }
+
+    // RemoveVolumeCmdIT#removeVolume
+    @DELETE
+    @Path("/{name}")
+    public Response removeVolume(@PathParam("name") String name) {
+        try {
+            dockerClient.removeVolumeCmd(name).exec();
+            return Response.noContent().build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+}

--- a/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/VolumeResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/docker/client/it/cmd/VolumeResource.java
@@ -1,19 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.quarkiverse.docker.client.it.cmd;
 
 import java.util.Collections;
@@ -35,11 +19,6 @@ import com.github.dockerjava.api.command.InspectVolumeResponse;
 import com.github.dockerjava.api.command.ListVolumesResponse;
 import com.github.dockerjava.api.exception.NotFoundException;
 
-/**
- * Mirrors docker-java's CreateVolumeCmdIT, InspectVolumeCmdIT, ListVolumesCmdIT
- * and RemoveVolumeCmdIT. Each docker command is exposed through its own REST
- * endpoint.
- */
 @Path("/docker-volume")
 @ApplicationScoped
 @Produces(MediaType.APPLICATION_JSON)
@@ -48,7 +27,6 @@ public class VolumeResource {
     @Inject
     DockerClient dockerClient;
 
-    // CreateVolumeCmdIT#createVolume
     @POST
     @Path("/{name}")
     public Response createVolume(@PathParam("name") String name) {
@@ -60,7 +38,6 @@ public class VolumeResource {
         return Response.ok(response).build();
     }
 
-    // InspectVolumeCmdIT#inspectVolume / inspectNonExistentVolume
     @GET
     @Path("/{name}")
     public Response inspectVolume(@PathParam("name") String name) {
@@ -72,14 +49,12 @@ public class VolumeResource {
         }
     }
 
-    // ListVolumesCmdIT#listVolumes
     @GET
     public Response listVolumes() {
         ListVolumesResponse response = dockerClient.listVolumesCmd().exec();
         return Response.ok(response).build();
     }
 
-    // RemoveVolumeCmdIT#removeVolume
     @DELETE
     @Path("/{name}")
     public Response removeVolume(@PathParam("name") String name) {

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -14,3 +14,6 @@ quarkus.docker.client1.read-timeout=45s
 quarkus.docker.client2.enabled=true
 quarkus.docker.client2.connect-timeout=20s
 quarkus.docker.client2.read-timeout=60s
+
+# RestAssured socket read timeout used by tests
+quarkus.http.test-timeout=180s

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/NamedDockerClientResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/NamedDockerClientResourceTest.java
@@ -17,7 +17,7 @@ import io.quarkus.test.junit.QuarkusTest;
 @Testcontainers
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class NamedDockerClientResourceTest {
+public class NamedDockerClientResourceTest {
 
     private static final String TEST_IMAGE = "nginx:alpine";
     private final Map<String, String> containerIds = new HashMap<>();

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/AttachContainerCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/AttachContainerCmdTest.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class AttachContainerCmdTest {
+
+    @Test
+    public void attachContainer() {
+        ensureBusybox();
+        given()
+                .when()
+                .queryParam("snippet", "hello world")
+                .post("/docker-container/attach-scenario")
+                .then()
+                .statusCode(200)
+                .body(containsString("hello world"));
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/BuildImageCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/BuildImageCmdTest.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.inspectImage;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeImage;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class BuildImageCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void buildImage() {
+        String imageId = null;
+        try {
+            imageId = given()
+                    .when()
+                    .post("/docker-image/build")
+                    .then()
+                    .statusCode(200)
+                    .extract()
+                    .asString();
+
+            inspectImage(imageId).statusCode(200).body("Config.Labels.test", equalTo("abc"));
+        } finally {
+            if (imageId != null) {
+                removeImage(imageId);
+            }
+        }
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/CmdTestSupport.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/CmdTestSupport.java
@@ -1,0 +1,87 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.not;
+
+import io.restassured.response.ValidatableResponse;
+
+/**
+ * Shared helpers for the per-command resource tests. These wrap the common
+ * docker-container / docker-image setup calls so each command test class stays
+ * focused on the single command it verifies.
+ */
+final class CmdTestSupport {
+
+    static final String BUSYBOX = "busybox:latest";
+
+    private CmdTestSupport() {
+    }
+
+    static void ensureBusybox() {
+        given().queryParam("image", BUSYBOX).post("/docker-image/ensure").then().statusCode(204);
+    }
+
+    static String createContainer(String cmd) {
+        return given()
+                .queryParam("image", BUSYBOX)
+                .queryParam("cmd", cmd)
+                .post("/docker-container/create")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+    }
+
+    static String createAndStartContainer(String cmd) {
+        String id = createContainer(cmd);
+        startContainer(id);
+        return id;
+    }
+
+    static void startContainer(String id) {
+        given().post("/docker-container/" + id + "/start").then().statusCode(204);
+    }
+
+    static void removeContainer(String id) {
+        try {
+            given().queryParam("force", true).delete("/docker-container/" + id);
+        } catch (Exception ignored) {
+        }
+    }
+
+    static void removeImage(String name) {
+        try {
+            given().queryParam("name", name).queryParam("force", true).delete("/docker-image");
+        } catch (Exception ignored) {
+        }
+    }
+
+    static void removeNetwork(String id) {
+        try {
+            given().delete("/docker-network/" + id);
+        } catch (Exception ignored) {
+        }
+    }
+
+    static void removeVolume(String name) {
+        try {
+            given().delete("/docker-volume/" + name);
+        } catch (Exception ignored) {
+        }
+    }
+
+    static String createNetwork(String name) {
+        return given()
+                .post("/docker-network/" + name)
+                .then()
+                .statusCode(200)
+                .body("Id", not(emptyOrNullString()))
+                .extract()
+                .path("Id");
+    }
+
+    static ValidatableResponse inspectImage(String name) {
+        return given().queryParam("name", name).when().get("/docker-image/inspect").then();
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/CommitCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/CommitCmdTest.java
@@ -1,0 +1,83 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.inspectImage;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeImage;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class CommitCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void commit() {
+        String containerId = createAndStartContainer("touch,/test");
+        String imageId = null;
+        try {
+            String busyboxId = inspectImage("busybox").statusCode(200).extract().path("Id");
+
+            imageId = given()
+                    .when()
+                    .post("/docker-image/commit/" + containerId)
+                    .then()
+                    .statusCode(200)
+                    .extract()
+                    .asString();
+
+            inspectImage(imageId).statusCode(200).body("Parent", equalTo(busyboxId));
+        } finally {
+            removeContainer(containerId);
+            if (imageId != null) {
+                removeImage(imageId);
+            }
+        }
+    }
+
+    @Test
+    public void commitWithLabels() {
+        String containerId = createAndStartContainer("touch,/test");
+        String imageId = null;
+        try {
+            given().post("/docker-container/" + containerId + "/wait").then().statusCode(200);
+
+            imageId = given()
+                    .when()
+                    .post("/docker-image/commit/" + containerId + "/labels")
+                    .then()
+                    .statusCode(200)
+                    .extract()
+                    .asString();
+
+            inspectImage(imageId)
+                    .statusCode(200)
+                    .body("Config.Labels.label1", equalTo("abc"))
+                    .body("Config.Labels.label2", equalTo("123"));
+        } finally {
+            removeContainer(containerId);
+            if (imageId != null) {
+                removeImage(imageId);
+            }
+        }
+    }
+
+    @Test
+    public void commitNonExistingContainer() {
+        given()
+                .when()
+                .post("/docker-image/commit/non-existent")
+                .then()
+                .statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ConnectToNetworkCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ConnectToNetworkCmdTest.java
@@ -1,0 +1,46 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createNetwork;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeNetwork;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.hasKey;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ConnectToNetworkCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void connectToNetwork() {
+        String containerId = createAndStartContainer("sleep,9999");
+        String networkId = createNetwork("connectToNetwork-" + System.nanoTime());
+        try {
+            given()
+                    .when()
+                    .post("/docker-network/" + networkId + "/connect/" + containerId)
+                    .then()
+                    .statusCode(204);
+
+            given()
+                    .when()
+                    .get("/docker-network/" + networkId)
+                    .then()
+                    .statusCode(200)
+                    .body("Containers", hasKey(containerId));
+        } finally {
+            removeContainer(containerId);
+            removeNetwork(networkId);
+        }
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ContainerDiffCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ContainerDiffCmdTest.java
@@ -1,0 +1,44 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class ContainerDiffCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void containerDiff() {
+        String id = createAndStartContainer("touch,/test");
+        try {
+            given().post("/docker-container/" + id + "/wait").then().statusCode(200);
+            given()
+                    .when()
+                    .get("/docker-container/" + id + "/diff")
+                    .then()
+                    .statusCode(200)
+                    .contentType(ContentType.JSON)
+                    .body("find { it.Path == '/test' }.Kind", equalTo(1));
+        } finally {
+            removeContainer(id);
+        }
+    }
+
+    @Test
+    public void containerDiffNonExisting() {
+        given().get("/docker-container/non-existing/diff").then().statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/CopyArchiveFromContainerCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/CopyArchiveFromContainerCmdTest.java
@@ -1,0 +1,53 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class CopyArchiveFromContainerCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void copyFromContainer() {
+        String id = createAndStartContainer("sleep,9999");
+        try {
+            given()
+                    .when()
+                    .queryParam("remotePath", "/")
+                    .queryParam("fileName", "copyFromContainer")
+                    .queryParam("content", "hello")
+                    .post("/docker-container/" + id + "/copy-to")
+                    .then()
+                    .statusCode(204);
+
+            byte[] tar = given()
+                    .when()
+                    .queryParam("resource", "/copyFromContainer")
+                    .get("/docker-container/" + id + "/copy-from")
+                    .then()
+                    .statusCode(200)
+                    .extract()
+                    .asByteArray();
+            Assertions.assertTrue(tar.length > 0);
+        } finally {
+            removeContainer(id);
+        }
+    }
+
+    @Test
+    public void copyFromNonExistingContainer() {
+        given().queryParam("resource", "/test").get("/docker-container/non-existing/copy-from").then().statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/CopyArchiveToContainerCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/CopyArchiveToContainerCmdTest.java
@@ -1,0 +1,60 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class CopyArchiveToContainerCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void copyToContainer() {
+        String id = createAndStartContainer("sleep,9999");
+        try {
+            given()
+                    .when()
+                    .queryParam("remotePath", "/")
+                    .queryParam("fileName", "testReadFile")
+                    .queryParam("content", "hello")
+                    .post("/docker-container/" + id + "/copy-to")
+                    .then()
+                    .statusCode(204);
+
+            byte[] tar = given()
+                    .when()
+                    .queryParam("resource", "/testReadFile")
+                    .get("/docker-container/" + id + "/copy-from")
+                    .then()
+                    .statusCode(200)
+                    .extract()
+                    .asByteArray();
+            Assertions.assertTrue(tar.length > 0);
+        } finally {
+            removeContainer(id);
+        }
+    }
+
+    @Test
+    public void copyToNonExistingContainer() {
+        given()
+                .when()
+                .queryParam("remotePath", "/")
+                .queryParam("fileName", "f")
+                .queryParam("content", "x")
+                .post("/docker-container/non-existing/copy-to")
+                .then()
+                .statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/CopyFileFromContainerCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/CopyFileFromContainerCmdTest.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class CopyFileFromContainerCmdTest {
+
+    @Test
+    public void copyFileFromNonExistingContainer() {
+        given().queryParam("resource", "/test").get("/docker-container/non-existing/copy-file-from").then()
+                .statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/CreateContainerCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/CreateContainerCmdTest.java
@@ -1,0 +1,85 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.BUSYBOX;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class CreateContainerCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void createContainer() {
+        String id = CmdTestSupport.createContainer("sleep,9999");
+        try {
+            Assertions.assertFalse(id.isEmpty());
+            given()
+                    .when()
+                    .get("/docker-container/" + id + "/inspect")
+                    .then()
+                    .statusCode(200)
+                    .contentType(ContentType.JSON)
+                    .body("Id", equalTo(id))
+                    .body("Config.Image", equalTo(BUSYBOX));
+        } finally {
+            remove(id);
+        }
+    }
+
+    @Test
+    public void createContainerWithNameEnvAndLabels() {
+        String name = "createTest-" + System.nanoTime();
+        String id = given()
+                .when()
+                .queryParam("image", BUSYBOX)
+                .queryParam("cmd", "env")
+                .queryParam("name", name)
+                .queryParam("env", "FOO=bar")
+                .queryParam("label", "com.example=test")
+                .post("/docker-container/create")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+        try {
+            given()
+                    .when()
+                    .get("/docker-container/" + id + "/inspect")
+                    .then()
+                    .statusCode(200)
+                    .body("Name", equalTo("/" + name))
+                    .body("Config.Env", hasItem("FOO=bar"))
+                    .body("Config.Labels.'com.example'", equalTo("test"));
+        } finally {
+            remove(id);
+        }
+    }
+
+    @Test
+    public void createContainerNonExistingImage() {
+        given()
+                .when()
+                .queryParam("image", "non-existing-image-xyz:latest")
+                .post("/docker-container/create")
+                .then()
+                .statusCode(404);
+    }
+
+    private void remove(String id) {
+        removeContainer(id);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/CreateNetworkCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/CreateNetworkCmdTest.java
@@ -1,0 +1,99 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeNetwork;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class CreateNetworkCmdTest {
+
+    @Test
+    public void createNetwork() {
+        String id = CmdTestSupport.createNetwork("createNetwork-" + System.nanoTime());
+        try {
+            given()
+                    .when()
+                    .get("/docker-network/" + id)
+                    .then()
+                    .statusCode(200)
+                    .contentType(ContentType.JSON)
+                    .body("Driver", equalTo("bridge"));
+        } finally {
+            removeNetwork(id);
+        }
+    }
+
+    @Test
+    public void createNetworkWithIpam() {
+        String name = "networkIpam-" + System.nanoTime();
+        String subnet = "10.67.79.0/24";
+        String id = given()
+                .when()
+                .queryParam("subnet", subnet)
+                .post("/docker-network/" + name + "/ipam")
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("Id");
+        try {
+            given()
+                    .when()
+                    .get("/docker-network/" + id)
+                    .then()
+                    .statusCode(200)
+                    .body("Driver", equalTo("bridge"))
+                    .body("IPAM.Config[0].Subnet", equalTo(subnet));
+        } finally {
+            removeNetwork(id);
+        }
+    }
+
+    @Test
+    public void createNetworkWithLabel() {
+        String name = "createNetworkWithLabel-" + System.nanoTime();
+        String id = given()
+                .when()
+                .post("/docker-network/" + name + "/label")
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("Id");
+        try {
+            given()
+                    .when()
+                    .get("/docker-network/" + id)
+                    .then()
+                    .statusCode(200)
+                    .body("Labels.'com.example.usage'", equalTo("test"));
+        } finally {
+            removeNetwork(id);
+        }
+    }
+
+    @Test
+    public void createAttachableNetwork() {
+        String name = "createAttachableNetwork-" + System.nanoTime();
+        String id = given()
+                .when()
+                .post("/docker-network/" + name + "/attachable")
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("Id");
+        try {
+            given()
+                    .when()
+                    .get("/docker-network/" + id)
+                    .then()
+                    .statusCode(200)
+                    .body("Attachable", equalTo(true));
+        } finally {
+            removeNetwork(id);
+        }
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/CreateVolumeCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/CreateVolumeCmdTest.java
@@ -1,0 +1,55 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class CreateVolumeCmdTest {
+
+    private static final String VOLUME_NAME = "volume1";
+
+    @AfterEach
+    public void cleanup() {
+        CmdTestSupport.removeVolume(VOLUME_NAME);
+    }
+
+    @Test
+    public void createVolume() {
+        given()
+                .when()
+                .post("/docker-volume/" + VOLUME_NAME)
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("Name", equalTo(VOLUME_NAME))
+                .body("Driver", equalTo("local"))
+                .body("Labels.'is-timelord'", equalTo("yes"))
+                .body("Mountpoint", containsString("/" + VOLUME_NAME + "/"));
+    }
+
+    @Test
+    public void createVolumeWithExistingName() {
+        String mountpoint1 = given()
+                .when()
+                .post("/docker-volume/" + VOLUME_NAME)
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("Mountpoint");
+
+        given()
+                .when()
+                .post("/docker-volume/" + VOLUME_NAME)
+                .then()
+                .statusCode(200)
+                .body("Name", equalTo(VOLUME_NAME))
+                .body("Mountpoint", equalTo(mountpoint1));
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/DisconnectFromNetworkCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/DisconnectFromNetworkCmdTest.java
@@ -1,0 +1,50 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createNetwork;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeNetwork;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class DisconnectFromNetworkCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void disconnectFromNetwork() {
+        String containerId = createAndStartContainer("sleep,9999");
+        String networkId = createNetwork("disconnectNetwork-" + System.nanoTime());
+        try {
+            given().post("/docker-network/" + networkId + "/connect/" + containerId).then().statusCode(204);
+            given().get("/docker-network/" + networkId).then().body("Containers", hasKey(containerId));
+
+            given()
+                    .when()
+                    .post("/docker-network/" + networkId + "/disconnect/" + containerId)
+                    .then()
+                    .statusCode(204);
+
+            given()
+                    .when()
+                    .get("/docker-network/" + networkId)
+                    .then()
+                    .statusCode(200)
+                    .body("Containers", not(hasKey(containerId)));
+        } finally {
+            removeContainer(containerId);
+            removeNetwork(networkId);
+        }
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/EventsCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/EventsCmdTest.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class EventsCmdTest {
+
+    @Test
+    public void events() {
+        given()
+                .when()
+                .get("/docker-system/events")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("size()", greaterThanOrEqualTo(1))
+                .body("findAll { it.Action == 'start' }.size()", greaterThanOrEqualTo(1));
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ExecCreateCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ExecCreateCmdTest.java
@@ -1,0 +1,39 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ExecCreateCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void execCreate() {
+        String containerId = createAndStartContainer("sleep,9999");
+        try {
+            String execId = given()
+                    .when()
+                    .queryParam("cmd", "touch,file.log")
+                    .post("/docker-exec/" + containerId + "/create")
+                    .then()
+                    .statusCode(200)
+                    .extract()
+                    .asString();
+            Assertions.assertFalse(execId.isEmpty());
+        } finally {
+            removeContainer(containerId);
+        }
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ExecStartCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ExecStartCmdTest.java
@@ -1,0 +1,52 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ExecStartCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    private String execCreate(String containerId, String cmd) {
+        return given()
+                .when()
+                .queryParam("cmd", cmd)
+                .post("/docker-exec/" + containerId + "/create")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+    }
+
+    @Test
+    public void execStart() {
+        String containerId = createAndStartContainer("sleep,9999");
+        try {
+            String touchExec = execCreate(containerId, "touch,/execStartTest.log");
+            given().post("/docker-exec/" + touchExec + "/start").then().statusCode(204);
+
+            String checkExec = execCreate(containerId, "test,-e,/execStartTest.log");
+            given().post("/docker-exec/" + checkExec + "/start").then().statusCode(204);
+            given()
+                    .when()
+                    .get("/docker-exec/" + checkExec + "/inspect")
+                    .then()
+                    .statusCode(200)
+                    .body("ExitCode", equalTo(0));
+        } finally {
+            removeContainer(containerId);
+        }
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/HealthCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/HealthCmdTest.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.BUSYBOX;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class HealthCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void healthContainer() {
+        String id = given()
+                .when()
+                .queryParam("image", BUSYBOX)
+                .queryParam("healthcheck", true)
+                .post("/docker-container/create")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+        try {
+            given().post("/docker-container/" + id + "/start").then().statusCode(204);
+            given()
+                    .when()
+                    .get("/docker-container/" + id + "/health")
+                    .then()
+                    .statusCode(200)
+                    .body(equalTo("healthy"));
+        } finally {
+            removeContainer(id);
+        }
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/InfoCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/InfoCmdTest.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class InfoCmdTest {
+
+    @Test
+    public void info() {
+        given()
+                .when()
+                .get("/docker-system/info")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("Containers", notNullValue())
+                .body("Images", notNullValue())
+                .body("NCPU", greaterThan(0));
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/InspectContainerCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/InspectContainerCmdTest.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class InspectContainerCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void inspectContainer() {
+        String id = createContainer("top");
+        try {
+            given()
+                    .when()
+                    .get("/docker-container/" + id + "/inspect")
+                    .then()
+                    .statusCode(200)
+                    .body("Id", equalTo(id))
+                    .body("RestartCount", equalTo(0));
+        } finally {
+            removeContainer(id);
+        }
+    }
+
+    @Test
+    public void inspectNonExistingContainer() {
+        given().get("/docker-container/non-existing/inspect").then().statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/InspectExecCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/InspectExecCmdTest.java
@@ -1,0 +1,71 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class InspectExecCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    private String execCreate(String containerId, String cmd) {
+        return given()
+                .when()
+                .queryParam("cmd", cmd)
+                .post("/docker-exec/" + containerId + "/create")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+    }
+
+    @Test
+    public void inspectExec() {
+        String containerId = createAndStartContainer("sleep,9999");
+        try {
+            String check1 = execCreate(containerId, "test,-e,/marker");
+            given().post("/docker-exec/" + check1 + "/start").then().statusCode(204);
+            given()
+                    .when()
+                    .get("/docker-exec/" + check1 + "/inspect")
+                    .then()
+                    .statusCode(200)
+                    .contentType(ContentType.JSON)
+                    .body("Running", equalTo(false))
+                    .body("ExitCode", equalTo(1));
+
+            String touch = execCreate(containerId, "touch,/marker");
+            given().post("/docker-exec/" + touch + "/start").then().statusCode(204);
+            given()
+                    .when()
+                    .get("/docker-exec/" + touch + "/inspect")
+                    .then()
+                    .statusCode(200)
+                    .body("Running", equalTo(false))
+                    .body("ExitCode", equalTo(0));
+
+            String check2 = execCreate(containerId, "test,-e,/marker");
+            given().post("/docker-exec/" + check2 + "/start").then().statusCode(204);
+            given()
+                    .when()
+                    .get("/docker-exec/" + check2 + "/inspect")
+                    .then()
+                    .statusCode(200)
+                    .body("ExitCode", equalTo(0));
+        } finally {
+            removeContainer(containerId);
+        }
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/InspectNetworkCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/InspectNetworkCmdTest.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class InspectNetworkCmdTest {
+
+    @Test
+    public void inspectNetwork() {
+        given()
+                .when()
+                .get("/docker-network/bridge")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("Name", equalTo("bridge"))
+                .body("Driver", equalTo("bridge"))
+                .body("Scope", equalTo("local"));
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/InspectVolumeCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/InspectVolumeCmdTest.java
@@ -1,0 +1,47 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class InspectVolumeCmdTest {
+
+    private static final String VOLUME_NAME = "volume1";
+
+    @AfterEach
+    public void cleanup() {
+        CmdTestSupport.removeVolume(VOLUME_NAME);
+    }
+
+    @Test
+    public void inspectVolume() {
+        given().post("/docker-volume/" + VOLUME_NAME).then().statusCode(200);
+
+        given()
+                .when()
+                .get("/docker-volume/" + VOLUME_NAME)
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("Name", equalTo(VOLUME_NAME))
+                .body("Driver", equalTo("local"))
+                .body("Labels.'is-timelord'", equalTo("yes"))
+                .body("Mountpoint", containsString("/" + VOLUME_NAME + "/"));
+    }
+
+    @Test
+    public void inspectNonExistentVolume() {
+        given()
+                .when()
+                .get("/docker-volume/non-existing")
+                .then()
+                .statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/KillContainerCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/KillContainerCmdTest.java
@@ -1,0 +1,44 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class KillContainerCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void killContainer() {
+        String id = createAndStartContainer("sleep,9999");
+        try {
+            given().post("/docker-container/" + id + "/kill").then().statusCode(204);
+            given()
+                    .when()
+                    .get("/docker-container/" + id + "/inspect")
+                    .then()
+                    .statusCode(200)
+                    .body("State.Running", equalTo(false))
+                    .body("State.ExitCode", not(equalTo(0)));
+        } finally {
+            removeContainer(id);
+        }
+    }
+
+    @Test
+    public void killNonExistingContainer() {
+        given().post("/docker-container/non-existing/kill").then().statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ListContainersCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ListContainersCmdTest.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class ListContainersCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void listContainers() {
+        String id = createAndStartContainer("sleep,9999");
+        try {
+            given()
+                    .when()
+                    .get("/docker-container")
+                    .then()
+                    .statusCode(200)
+                    .contentType(ContentType.JSON)
+                    .body("find { it.Id == '" + id + "' }", notNullValue())
+                    .body("find { it.Id == '" + id + "' }.Image", startsWith("busybox"));
+        } finally {
+            removeContainer(id);
+        }
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ListImagesCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ListImagesCmdTest.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class ListImagesCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void listImages() {
+        given()
+                .when()
+                .get("/docker-image")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("size()", greaterThan(0))
+                .body("[0].Id", not(emptyOrNullString()))
+                .body("[0].Created", notNullValue())
+                .body("[0].Size", notNullValue());
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ListNetworksCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ListNetworksCmdTest.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class ListNetworksCmdTest {
+
+    @Test
+    public void listNetworks() {
+        given()
+                .when()
+                .get("/docker-network")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("find { it.Name == 'bridge' }.Scope", equalTo("local"))
+                .body("find { it.Name == 'bridge' }.Driver", equalTo("bridge"))
+                .body("find { it.Name == 'bridge' }.IPAM.Driver", equalTo("default"));
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ListVolumesCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ListVolumesCmdTest.java
@@ -1,0 +1,36 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class ListVolumesCmdTest {
+
+    private static final String VOLUME_NAME = "volume1";
+
+    @AfterEach
+    public void cleanup() {
+        CmdTestSupport.removeVolume(VOLUME_NAME);
+    }
+
+    @Test
+    public void listVolumes() {
+        given().post("/docker-volume/" + VOLUME_NAME).then().statusCode(200);
+
+        given()
+                .when()
+                .get("/docker-volume")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("Volumes.size()", greaterThanOrEqualTo(1))
+                .body("Volumes.Name", hasItem(VOLUME_NAME));
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/LoadImageCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/LoadImageCmdTest.java
@@ -1,0 +1,28 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class LoadImageCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void loadImage() {
+        given()
+                .when()
+                .queryParam("name", "busybox")
+                .post("/docker-image/load")
+                .then()
+                .statusCode(204);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/LogContainerCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/LogContainerCmdTest.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class LogContainerCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void logContainer() {
+        String id = createAndStartContainer("/bin/echo,hello world");
+        try {
+            given().post("/docker-container/" + id + "/wait").then().statusCode(200);
+            given()
+                    .when()
+                    .get("/docker-container/" + id + "/logs")
+                    .then()
+                    .statusCode(200)
+                    .body(containsString("hello world"));
+        } finally {
+            removeContainer(id);
+        }
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/PauseCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/PauseCmdTest.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class PauseCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void pauseRunningContainer() {
+        String id = createAndStartContainer("sleep,9999");
+        try {
+            given().post("/docker-container/" + id + "/pause").then().statusCode(204);
+            given()
+                    .when()
+                    .get("/docker-container/" + id + "/inspect")
+                    .then()
+                    .statusCode(200)
+                    .body("State.Paused", equalTo(true));
+        } finally {
+            removeContainer(id);
+        }
+    }
+
+    @Test
+    public void pauseNonExistingContainer() {
+        given().post("/docker-container/non-existing/pause").then().statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/PingCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/PingCmdTest.java
@@ -1,0 +1,20 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class PingCmdTest {
+
+    @Test
+    public void ping() {
+        given()
+                .when()
+                .get("/docker-system/ping")
+                .then()
+                .statusCode(204);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/PullImageCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/PullImageCmdTest.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.inspectImage;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeImage;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class PullImageCmdTest {
+
+    @Test
+    public void pullImage() {
+        String image = "alpine:3.17";
+        removeImage(image);
+
+        given()
+                .when()
+                .queryParam("image", image)
+                .post("/docker-image/pull")
+                .then()
+                .statusCode(204);
+
+        inspectImage(image)
+                .statusCode(200)
+                .body("Id", not(emptyOrNullString()));
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/RemoveContainerCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/RemoveContainerCmdTest.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class RemoveContainerCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void removeContainer() {
+        String id = createAndStartContainer("true");
+        given().post("/docker-container/" + id + "/wait").then().statusCode(200);
+
+        given().delete("/docker-container/" + id).then().statusCode(204);
+
+        given()
+                .when()
+                .get("/docker-container")
+                .then()
+                .statusCode(200)
+                .body("find { it.Id == '" + id + "' }", nullValue());
+    }
+
+    @Test
+    public void removeNonExistingContainer() {
+        given().delete("/docker-container/non-existing").then().statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/RemoveImageCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/RemoveImageCmdTest.java
@@ -1,0 +1,21 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class RemoveImageCmdTest {
+
+    @Test
+    public void removeNonExistingImage() {
+        given()
+                .when()
+                .queryParam("name", "non-existing")
+                .delete("/docker-image")
+                .then()
+                .statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/RemoveNetworkCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/RemoveNetworkCmdTest.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createNetwork;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class RemoveNetworkCmdTest {
+
+    @Test
+    public void removeNetwork() {
+        String id = createNetwork("test-network-" + System.nanoTime());
+
+        given()
+                .when()
+                .delete("/docker-network/" + id)
+                .then()
+                .statusCode(204);
+
+        given()
+                .when()
+                .get("/docker-network")
+                .then()
+                .statusCode(200)
+                .body("find { it.Id == '" + id + "' }", nullValue());
+    }
+
+    @Test
+    public void removeNonExistingNetwork() {
+        given()
+                .when()
+                .delete("/docker-network/non-existing")
+                .then()
+                .statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/RemoveVolumeCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/RemoveVolumeCmdTest.java
@@ -1,0 +1,36 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class RemoveVolumeCmdTest {
+
+    private static final String VOLUME_NAME = "volume1";
+
+    @AfterEach
+    public void cleanup() {
+        CmdTestSupport.removeVolume(VOLUME_NAME);
+    }
+
+    @Test
+    public void removeVolume() {
+        given().post("/docker-volume/" + VOLUME_NAME).then().statusCode(200);
+
+        given()
+                .when()
+                .delete("/docker-volume/" + VOLUME_NAME)
+                .then()
+                .statusCode(204);
+
+        given()
+                .when()
+                .get("/docker-volume/" + VOLUME_NAME)
+                .then()
+                .statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/RenameContainerCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/RenameContainerCmdTest.java
@@ -1,0 +1,43 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class RenameContainerCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void renameContainer() {
+        String id = createAndStartContainer("sleep,9999");
+        try {
+            String newName = "renamed-" + System.nanoTime();
+            given().queryParam("name", newName).post("/docker-container/" + id + "/rename").then().statusCode(204);
+            given()
+                    .when()
+                    .get("/docker-container/" + id + "/inspect")
+                    .then()
+                    .statusCode(200)
+                    .body("Name", equalTo("/" + newName));
+        } finally {
+            removeContainer(id);
+        }
+    }
+
+    @Test
+    public void renameNonExistingContainer() {
+        given().queryParam("name", "foo").post("/docker-container/non-existing/rename").then().statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ResizeContainerCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ResizeContainerCmdTest.java
@@ -1,0 +1,50 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.BUSYBOX;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ResizeContainerCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void resizeContainer() {
+        String id = given()
+                .when()
+                .queryParam("image", BUSYBOX)
+                .queryParam("cmd", "sh,-c,until stty size | grep '30 120'; do : ; done")
+                .queryParam("tty", true)
+                .queryParam("stdinOpen", true)
+                .queryParam("user", "root")
+                .post("/docker-container/create")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+        try {
+            given().post("/docker-container/" + id + "/start").then().statusCode(204);
+            given().queryParam("height", 30).queryParam("width", 120).post("/docker-container/" + id + "/resize").then()
+                    .statusCode(204);
+            given()
+                    .when()
+                    .post("/docker-container/" + id + "/wait")
+                    .then()
+                    .statusCode(200)
+                    .body(equalTo("0"));
+        } finally {
+            removeContainer(id);
+        }
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ResizeExecCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/ResizeExecCmdTest.java
@@ -1,0 +1,36 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ResizeExecCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void resizeExec() {
+        String containerId = createAndStartContainer("sleep,9999");
+        try {
+            given()
+                    .when()
+                    .post("/docker-exec/" + containerId + "/resize-scenario")
+                    .then()
+                    .statusCode(200)
+                    .body("completed", equalTo(true));
+        } finally {
+            removeContainer(containerId);
+        }
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/RestartContainerCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/RestartContainerCmdTest.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class RestartContainerCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void restartContainer() {
+        String id = createAndStartContainer("sleep,9999");
+        try {
+            String startedAt1 = given().get("/docker-container/" + id + "/inspect")
+                    .then().statusCode(200).extract().path("State.StartedAt");
+
+            given().queryParam("timeout", 2).post("/docker-container/" + id + "/restart").then().statusCode(204);
+
+            given()
+                    .when()
+                    .get("/docker-container/" + id + "/inspect")
+                    .then()
+                    .statusCode(200)
+                    .body("State.Running", equalTo(true))
+                    .body("State.StartedAt", not(equalTo(startedAt1)));
+        } finally {
+            removeContainer(id);
+        }
+    }
+
+    @Test
+    public void restartNonExistingContainer() {
+        given().post("/docker-container/non-existing/restart").then().statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/SaveImageCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/SaveImageCmdTest.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class SaveImageCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void saveImage() {
+        byte[] tar = given()
+                .when()
+                .queryParam("name", "busybox")
+                .get("/docker-image/save")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asByteArray();
+        Assertions.assertTrue(tar.length > 0);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/SaveImagesCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/SaveImagesCmdTest.java
@@ -1,0 +1,33 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class SaveImagesCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void saveImages() {
+        byte[] tar = given()
+                .when()
+                .queryParam("repository", "busybox")
+                .queryParam("tag", "latest")
+                .get("/docker-image/save-images")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asByteArray();
+        Assertions.assertTrue(tar.length > 0);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/StartContainerCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/StartContainerCmdTest.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class StartContainerCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void startContainer() {
+        String id = createAndStartContainer("top");
+        try {
+            given()
+                    .when()
+                    .get("/docker-container/" + id + "/inspect")
+                    .then()
+                    .statusCode(200)
+                    .body("State.Running", equalTo(true));
+        } finally {
+            removeContainer(id);
+        }
+    }
+
+    @Test
+    public void startNonExistingContainer() {
+        given().post("/docker-container/non-existing/start").then().statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/StatsCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/StatsCmdTest.java
@@ -1,0 +1,38 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class StatsCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void statsContainer() {
+        String id = createAndStartContainer("top");
+        try {
+            given()
+                    .when()
+                    .get("/docker-container/" + id + "/stats")
+                    .then()
+                    .statusCode(200)
+                    .contentType(ContentType.JSON)
+                    .body("read", notNullValue());
+        } finally {
+            removeContainer(id);
+        }
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/StopContainerCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/StopContainerCmdTest.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class StopContainerCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void stopContainer() {
+        String id = createAndStartContainer("sleep,9999");
+        try {
+            given().queryParam("timeout", 2).post("/docker-container/" + id + "/stop").then().statusCode(204);
+            given()
+                    .when()
+                    .get("/docker-container/" + id + "/inspect")
+                    .then()
+                    .statusCode(200)
+                    .body("State.Running", equalTo(false));
+        } finally {
+            removeContainer(id);
+        }
+    }
+
+    @Test
+    public void stopNonExistingContainer() {
+        given().post("/docker-container/non-existing/stop").then().statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/TagImageCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/TagImageCmdTest.java
@@ -1,0 +1,53 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.BUSYBOX;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.inspectImage;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeImage;
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class TagImageCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void tagImage() {
+        String tag = String.valueOf(Math.abs(System.nanoTime()));
+        String tagged = "docker-java/busybox:" + tag;
+        try {
+            given()
+                    .when()
+                    .queryParam("image", BUSYBOX)
+                    .queryParam("repository", "docker-java/busybox")
+                    .queryParam("tag", tag)
+                    .post("/docker-image/tag")
+                    .then()
+                    .statusCode(204);
+
+            inspectImage(tagged).statusCode(200);
+        } finally {
+            removeImage(tagged);
+        }
+    }
+
+    @Test
+    public void tagNonExistingImage() {
+        given()
+                .when()
+                .queryParam("image", "non-existing")
+                .queryParam("repository", "docker-java/busybox")
+                .queryParam("tag", "1")
+                .post("/docker-image/tag")
+                .then()
+                .statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/UnpauseCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/UnpauseCmdTest.java
@@ -1,0 +1,38 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class UnpauseCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void unpausePausedContainer() {
+        String id = createAndStartContainer("sleep,9999");
+        try {
+            given().post("/docker-container/" + id + "/pause").then().statusCode(204);
+            given().post("/docker-container/" + id + "/unpause").then().statusCode(204);
+            given()
+                    .when()
+                    .get("/docker-container/" + id + "/inspect")
+                    .then()
+                    .statusCode(200)
+                    .body("State.Paused", equalTo(false));
+        } finally {
+            removeContainer(id);
+        }
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/UpdateContainerCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/UpdateContainerCmdTest.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class UpdateContainerCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void updateContainer() {
+        String id = createAndStartContainer("sleep,9999");
+        try {
+            given().post("/docker-container/" + id + "/update").then().statusCode(204);
+            given()
+                    .when()
+                    .get("/docker-container/" + id + "/inspect")
+                    .then()
+                    .statusCode(200)
+                    .body("HostConfig.CpuShares", equalTo(512))
+                    .body("HostConfig.CpuPeriod", equalTo(100000))
+                    .body("HostConfig.CpuQuota", equalTo(50000))
+                    .body("HostConfig.CpusetMems", equalTo("0"));
+        } finally {
+            removeContainer(id);
+        }
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/VersionCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/VersionCmdTest.java
@@ -1,0 +1,28 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class VersionCmdTest {
+
+    @Test
+    public void version() {
+        given()
+                .when()
+                .get("/docker-system/version")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("Version", not(emptyOrNullString()))
+                .body("GoVersion", not(emptyOrNullString()))
+                .body("Version.split('\\\\.').size()", greaterThanOrEqualTo(3));
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/WaitContainerCmdTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/WaitContainerCmdTest.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.docker.client.it.cmd;
+
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.createAndStartContainer;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.ensureBusybox;
+import static io.quarkiverse.docker.client.it.cmd.CmdTestSupport.removeContainer;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class WaitContainerCmdTest {
+
+    @BeforeEach
+    public void setUp() {
+        ensureBusybox();
+    }
+
+    @Test
+    public void waitContainer() {
+        String id = createAndStartContainer("true");
+        try {
+            given()
+                    .when()
+                    .post("/docker-container/" + id + "/wait")
+                    .then()
+                    .statusCode(200)
+                    .body(equalTo("0"));
+        } finally {
+            removeContainer(id);
+        }
+    }
+
+    @Test
+    public void waitNonExistingContainer() {
+        given().post("/docker-container/non-existing/wait").then().statusCode(404);
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/AttachContainerCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/AttachContainerCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.AttachContainerCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class AttachContainerCmdTestIT extends AttachContainerCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/BuildImageCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/BuildImageCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.BuildImageCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class BuildImageCmdTestIT extends BuildImageCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/CommitCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/CommitCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.CommitCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class CommitCmdTestIT extends CommitCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ConnectToNetworkCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ConnectToNetworkCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.ConnectToNetworkCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class ConnectToNetworkCmdTestIT extends ConnectToNetworkCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ContainerDiffCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ContainerDiffCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.ContainerDiffCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class ContainerDiffCmdTestIT extends ContainerDiffCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/CopyArchiveFromContainerCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/CopyArchiveFromContainerCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.CopyArchiveFromContainerCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class CopyArchiveFromContainerCmdTestIT extends CopyArchiveFromContainerCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/CopyArchiveToContainerCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/CopyArchiveToContainerCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.CopyArchiveToContainerCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class CopyArchiveToContainerCmdTestIT extends CopyArchiveToContainerCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/CopyFileFromContainerCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/CopyFileFromContainerCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.CopyFileFromContainerCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class CopyFileFromContainerCmdTestIT extends CopyFileFromContainerCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/CreateContainerCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/CreateContainerCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.CreateContainerCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class CreateContainerCmdTestIT extends CreateContainerCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/CreateNetworkCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/CreateNetworkCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.CreateNetworkCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class CreateNetworkCmdTestIT extends CreateNetworkCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/CreateVolumeCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/CreateVolumeCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.CreateVolumeCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class CreateVolumeCmdTestIT extends CreateVolumeCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/DisconnectFromNetworkCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/DisconnectFromNetworkCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.DisconnectFromNetworkCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class DisconnectFromNetworkCmdTestIT extends DisconnectFromNetworkCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/EventsCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/EventsCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.EventsCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class EventsCmdTestIT extends EventsCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ExecCreateCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ExecCreateCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.ExecCreateCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class ExecCreateCmdTestIT extends ExecCreateCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ExecStartCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ExecStartCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.ExecStartCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class ExecStartCmdTestIT extends ExecStartCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/HealthCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/HealthCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.HealthCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class HealthCmdTestIT extends HealthCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/InfoCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/InfoCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.InfoCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class InfoCmdTestIT extends InfoCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/InspectContainerCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/InspectContainerCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.InspectContainerCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class InspectContainerCmdTestIT extends InspectContainerCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/InspectExecCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/InspectExecCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.InspectExecCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class InspectExecCmdTestIT extends InspectExecCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/InspectNetworkCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/InspectNetworkCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.InspectNetworkCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class InspectNetworkCmdTestIT extends InspectNetworkCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/InspectVolumeCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/InspectVolumeCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.InspectVolumeCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class InspectVolumeCmdTestIT extends InspectVolumeCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/KillContainerCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/KillContainerCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.KillContainerCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class KillContainerCmdTestIT extends KillContainerCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ListContainersCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ListContainersCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.ListContainersCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class ListContainersCmdTestIT extends ListContainersCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ListImagesCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ListImagesCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.ListImagesCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class ListImagesCmdTestIT extends ListImagesCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ListNetworksCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ListNetworksCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.ListNetworksCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class ListNetworksCmdTestIT extends ListNetworksCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ListVolumesCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ListVolumesCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.ListVolumesCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class ListVolumesCmdTestIT extends ListVolumesCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/LoadImageCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/LoadImageCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.LoadImageCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class LoadImageCmdTestIT extends LoadImageCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/LogContainerCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/LogContainerCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.LogContainerCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class LogContainerCmdTestIT extends LogContainerCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/PauseCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/PauseCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.PauseCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class PauseCmdTestIT extends PauseCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/PingCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/PingCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.PingCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class PingCmdTestIT extends PingCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/PullImageCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/PullImageCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.PullImageCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class PullImageCmdTestIT extends PullImageCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/RemoveContainerCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/RemoveContainerCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.RemoveContainerCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class RemoveContainerCmdTestIT extends RemoveContainerCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/RemoveImageCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/RemoveImageCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.RemoveImageCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class RemoveImageCmdTestIT extends RemoveImageCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/RemoveNetworkCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/RemoveNetworkCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.RemoveNetworkCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class RemoveNetworkCmdTestIT extends RemoveNetworkCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/RemoveVolumeCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/RemoveVolumeCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.RemoveVolumeCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class RemoveVolumeCmdTestIT extends RemoveVolumeCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/RenameContainerCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/RenameContainerCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.RenameContainerCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class RenameContainerCmdTestIT extends RenameContainerCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ResizeContainerCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ResizeContainerCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.ResizeContainerCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class ResizeContainerCmdTestIT extends ResizeContainerCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ResizeExecCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/ResizeExecCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.ResizeExecCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class ResizeExecCmdTestIT extends ResizeExecCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/RestartContainerCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/RestartContainerCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.RestartContainerCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class RestartContainerCmdTestIT extends RestartContainerCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/SaveImageCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/SaveImageCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.SaveImageCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class SaveImageCmdTestIT extends SaveImageCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/SaveImagesCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/SaveImagesCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.SaveImagesCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class SaveImagesCmdTestIT extends SaveImagesCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/StartContainerCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/StartContainerCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.StartContainerCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class StartContainerCmdTestIT extends StartContainerCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/StatsCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/StatsCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.StatsCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class StatsCmdTestIT extends StatsCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/StopContainerCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/StopContainerCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.StopContainerCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class StopContainerCmdTestIT extends StopContainerCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/TagImageCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/TagImageCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.TagImageCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class TagImageCmdTestIT extends TagImageCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/UnpauseCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/UnpauseCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.UnpauseCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class UnpauseCmdTestIT extends UnpauseCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/UpdateContainerCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/UpdateContainerCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.UpdateContainerCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class UpdateContainerCmdTestIT extends UpdateContainerCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/VersionCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/VersionCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.VersionCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class VersionCmdTestIT extends VersionCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/WaitContainerCmdTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/cmd/qit/WaitContainerCmdTestIT.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.docker.client.it.cmd.qit;
+
+import io.quarkiverse.docker.client.it.cmd.WaitContainerCmdTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class WaitContainerCmdTestIT extends WaitContainerCmdTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/qit/DockerClientResourceTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/qit/DockerClientResourceTestIT.java
@@ -1,5 +1,6 @@
-package io.quarkiverse.docker.client.it;
+package io.quarkiverse.docker.client.it.qit;
 
+import io.quarkiverse.docker.client.it.DockerClientResourceTest;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest

--- a/integration-tests/src/test/java/io/quarkiverse/docker/client/it/qit/NamedDockerClientResourceTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docker/client/it/qit/NamedDockerClientResourceTestIT.java
@@ -1,5 +1,6 @@
-package io.quarkiverse.docker.client.it;
+package io.quarkiverse.docker.client.it.qit;
 
+import io.quarkiverse.docker.client.it.NamedDockerClientResourceTest;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest


### PR DESCRIPTION
Closes: #106
In this PR I have mirrored  integration tests related to Docker commands from [docker-java](https://github.com/docker-java/docker-java/tree/main/docker-java-core/src/main/java/com/github/dockerjava/core/command) project and made sure that all commands are supported in native image build.